### PR TITLE
added multipolygon tests and update geotrellis version to 1.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name := "geotrellis-spark-sql"
 
 organization := "astraea"
 
-version := "0.2.3-SNAPSHOT"
+version := "0.2.4-SNAPSHOT"
 
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 
@@ -18,7 +18,7 @@ resolvers ++= Seq(
 )
 
 
-def geotrellis(module: String) = "org.locationtech.geotrellis" %% s"geotrellis-$module" % "1.1.0-RC5"
+def geotrellis(module: String) = "org.locationtech.geotrellis" %% s"geotrellis-$module" % "1.1.1"
 
 def spark(module: String) = "org.apache.spark" %% s"spark-$module" % "2.1.0"
 

--- a/src/main/scala/org/apache/spark/sql/gt/types/Registrator.scala
+++ b/src/main/scala/org/apache/spark/sql/gt/types/Registrator.scala
@@ -35,5 +35,6 @@ private[gt] object Registrator {
     MultiLineUDT
     PointUDT
     PolygonUDT
+    MultiPolygonUDT
   }
 }

--- a/src/test/scala/org/apache/spark/sql/gt/GeometryEncodingSpec.scala
+++ b/src/test/scala/org/apache/spark/sql/gt/GeometryEncodingSpec.scala
@@ -33,6 +33,27 @@ class GeometryEncodingSpec extends FunSpec
       assert(right.count() === 1)
     }
   }
+
+
+  describe("multipolygon encoding support") {
+    it("should not throw a runtime error") {
+      import sqlContext.implicits._
+      val polyA = Polygon(Line(Point(0,0), Point(1,0), Point(1,1), Point(0,1), Point(0,0)))
+      val polyB = Polygon(List(Point(10,10), Point(11,10), Point(11,11), Point(10,11), Point(10,10)))
+      val polyC = Polygon(List(Point(100,100), Point(101,100), Point(101,101), Point(100,101), Point(100,100)))
+      val polyD = Polygon(List(Point(120,120), Point(121,120), Point(121,121), Point(120,121), Point(120,120)))
+      val polyE = Polygon(List(Point(130,130), Point(131,130), Point(131,131), Point(130,131), Point(130,130)))
+
+      val left: RDD[MultiPolygon] = sc.parallelize(Array(MultiPolygon(Array(polyA, polyB)),MultiPolygon(Array(polyC, polyD, polyE))))
+      val multipolygon = left.toDS
+      multipolygon.show(false)
+      assert(multipolygon.count() === 2)
+
+      assert(multipolygon.head.polygons.size === 2)
+    }
+  }
+
+
 }
 
 object GeometryEncodingSpec {


### PR DESCRIPTION
I have added a test for multipolygons encoding and update the geotrellis verion to 1.1.1

I haven't changed the geotrellis-spark-sql version to 0.2.5-SNAPSHOT